### PR TITLE
fix: use public langflow image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
 version: "3.9"
 services:
   langflow:
-    image: ghcr.io/langflow-ai/langflow:latest
+    # Use the public Docker Hub image for Langflow instead of the GitHub
+    # Container Registry version, which requires authentication and caused
+    # deployment failures.
+    image: langflowai/langflow:latest
     environment:
       - PORT=7860
     ports:


### PR DESCRIPTION
## Summary
- use public `langflowai/langflow` image to avoid denied pull

## Testing
- `npm --prefix apps/web run build` *(fails: terminated early in CI environment)*
- `npm --prefix apps/api run start` *(fails: SyntaxError in ai.js)*

------
https://chatgpt.com/codex/tasks/task_e_689ce2bcf9988332b5e91131ac7b1be0