### PR TITLE
fix: use public langflow image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: "3.9"
 services:
   langflow:
-    image: ghcr.io/langflow-ai/langflow:latest
+    # Use the public Docker Hub image to avoid authentication issues with GHCR
+    image: langflowai/langflow:latest
     environment:
       - PORT=7860
     ports:


### PR DESCRIPTION
## Summary
- use public Docker Hub langflow image instead of GHCR to avoid pull denial

## Testing
- `docker compose config` *(fails: command not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce5f17a50833296cd0a834ff2601d